### PR TITLE
Import Lodash submodules, fixes #2

### DIFF
--- a/__tests__/collection-test.js
+++ b/__tests__/collection-test.js
@@ -1,6 +1,6 @@
 import { extendObservable, observable } from 'mobx'
 import collection from '../src/collection'
-import _ from 'lodash'
+import identity from 'lodash/identity'
 
 const testData = [
   { id: "1", name: "first" },
@@ -17,20 +17,20 @@ describe('Collections - init', () => {
 
   it('will use lodash identity as factory by default', () => {
     const testCollection = collection([])
-    expect(testCollection.$collection.factory).toBe(_.identity)
+    expect(testCollection.$collection.factory).toBe(identity)
   })
 
   it('can be assigned a name in the same argument place as factories', () => {
     const testCollection = collection([], 'TestCollection')
 
-    expect(testCollection.$collection.factory).toBe(_.identity)
+    expect(testCollection.$collection.factory).toBe(identity)
     expect(testCollection.$collection.name).toBe('TestCollection')
   })
 
   it('is named `Collection` by default', () => {
     const testCollection = collection([])
 
-    expect(testCollection.$collection.factory).toBe(_.identity)
+    expect(testCollection.$collection.factory).toBe(identity)
     expect(testCollection.$collection.name).toBe('Collection')
   })
 })
@@ -60,7 +60,7 @@ describe('Collections - setItems', () => {
     collectionActions.setItems('newItem')
     expect(testCollection[0]).toBe('newItem')
 
-    collectionActions.setItems(_.identity)
+    collectionActions.setItems(identity)
     expect(testCollection[0]('haha')).toBe('haha')
 
     expect(testCollection.length).toBe(1) // yup still 1 length

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import pick from 'lodash/pick'
 
 export default (...keys) => ({ actions, state }) => {
   // If no keys were specified, just return the action and state
@@ -6,7 +6,7 @@ export default (...keys) => ({ actions, state }) => {
   if( keys[0] === 'state' ) return { state }
 
   return {
-    ..._.pick(actions, keys),
+    ...pick(actions, keys),
     state
   }
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,11 +1,11 @@
 import { observable } from 'mobx'
-import _ from 'lodash'
+import forOwn from 'lodash/forOwn'
 
 export default (stores = {}, initialData = {}) => {
   const state = observable({})
   const actions = {}
 
-  _.forOwn(stores, (store, key) => {
+  forOwn(stores, (store, key) => {
     const storeActions = store(state, initialData, key)
     actions[ key ] = storeActions
   })

--- a/src/value.js
+++ b/src/value.js
@@ -1,12 +1,12 @@
 import { action, extendObservable } from 'mobx'
-import _ from 'lodash'
+import upperFirst from 'lodash/upperFirst'
 
 export default (state, property, initial = null) => {
 
   const setValue = action(`Value ${property} - Set value`, (value = initial) => state[property] = value )
   const extendValue = action(`Value ${property} - Extend value`, (value = initial) => extendObservable(state[property], value))
 
-  const methodSuffix = _.upperFirst(property)
+  const methodSuffix = upperFirst(property)
 
   // Because why not yeah
   return {


### PR DESCRIPTION
You can directly access individual functions as sub-modules from the main lodash module.
Only the parts of Lodash you need will be included in your build and nothing else.

*note: this change is based on `master` branch.*